### PR TITLE
Nugget - v4.5.33

### DIFF
--- a/NuggetSDK.podspec
+++ b/NuggetSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NuggetSDK'
-  s.version          = '4.5.32'
+  s.version          = '4.5.33'
   s.summary          = 'The Nugget SDK for iOS.'
   s.description      = <<-DESC
                      A longer description of NuggetSDK.
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
     }
 
     echo "Downloading and unzipping Nugget..."
-    curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.32-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
-    verify_checksum "Nugget.xcframework.zip" "b39a357482cc34f473a61a020784d6c53a33181a3d7f42fc56cbdc317b6fb0ba"
+    curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.33-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
+    verify_checksum "Nugget.xcframework.zip" "62ab0213a4533a679957c488e3d17a0f0200daba9299e9127b1c297463f5c015"
     unzip -o Nugget.xcframework.zip
     rm Nugget.xcframework.zip
   CMD

--- a/NuggetSDKExample/NuggetSDKExample.xcodeproj/project.pbxproj
+++ b/NuggetSDKExample/NuggetSDKExample.xcodeproj/project.pbxproj
@@ -595,7 +595,7 @@
 			repositoryURL = "https://github.com/Zomato-Nugget/nugget-sdk-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 4.5.23;
+				version = 4.5.32;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/NuggetSDKExample/NuggetSDKExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NuggetSDKExample/NuggetSDKExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Zomato-Nugget/nugget-sdk-ios",
       "state" : {
-        "revision" : "4a207f5b4bb614139f251eddc61d2d4e2050430c",
-        "version" : "4.5.23"
+        "revision" : "e61bd0dcc5a0232132a7a5658730b8934873472f",
+        "version" : "4.5.32"
       }
     }
   ],

--- a/NuggetSDKExample/NuggetSDKExample/AppDelegate.swift
+++ b/NuggetSDKExample/NuggetSDKExample/AppDelegate.swift
@@ -8,12 +8,13 @@
 import UIKit
 import CoreData
 import UserNotifications
+import NuggetSDK
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
     
     var shouldShowLockScreen: Bool = false
-    
+
     private lazy var appLockView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.white // Or any other color/image for your app lock screen
@@ -33,11 +34,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
     }()
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Set notification delegate
+
+        // 1. Become the notification-center delegate BEFORE launch finishes. Required so that
+        //    `willPresent` (foreground) and `didReceive` (tap) callbacks reach us.
         UNUserNotificationCenter.current().delegate = self
-        
-        // Request authorization
+
+        // 2. Ask for permission, forward the result to Nugget, and register with APNs on grant.
+        //    (The factory that uploads the token is created lazily by the UI layer on first chat
+        //    open — see `ViewController` — so nothing is built here.)
         UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            // Forward the (possibly just-changed) permission status to Nugget's static listener.
+            NuggetService.notificationListener.refreshPermissionStatus()
+
             if granted {
                 print("Push notification permission granted")
                 DispatchQueue.main.async {
@@ -50,55 +58,85 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         setupAppLockObservers()
         return true
     }
-    
+
     // MARK: UISceneSession Lifecycle
-    
+
     func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
         // Called when a new scene session is being created.
         // Use this method to select a configuration to create the new scene with.
         return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
     }
-    
-    // MARK: - Push Notification Methods
-    
+
+    // MARK: - APNs Registration
+
+    /// APNs handed us the device token — forward it to the listener so the backend can target this
+    /// device.
+    ///
+    /// The listener hex-encodes the token, caches it, and (once the chat factory exists) uploads it
+    /// to Nugget. If you also use FCM, set `Messaging.messaging().apnsToken` here too (and disable
+    /// FCM method swizzling) — Nugget needs the **raw APNs token**, not the FCM registration token.
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
-        let token = tokenParts.joined()
+        let token = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
         print("Device Token: \(token)")
-        
-        // Save token for later use
-        UserDefaults.standard.set(token, forKey: "deviceToken")
+
+        // Hand the raw token to Nugget's single static listener.
+        NuggetService.notificationListener.updateNotificationToken(deviceToken)
     }
-    
+
+    /// APNs registration failed (e.g. no network, no entitlement, Simulator without a signed-in
+    /// Apple ID). Nugget simply won't receive a token this session.
     func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         print("Failed to register for remote notifications: \(error.localizedDescription)")
     }
-    
-    // MARK: - UNUserNotificationCenterDelegate Methods
-    
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// A notification arrived while the app is in the **foreground** (in-app notification).
+    ///
+    /// We ask the listener how to present it. By default a Nugget push is shown as a banner;
+    /// pass `isViewingChat: true` to suppress it when the user is already in that conversation.
     func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-        // Handle foreground notifications
-        completionHandler([.banner, .sound, .badge])
+        let userInfo = notification.request.content.userInfo
+
+        // Hook your own "is this chat already on screen?" logic in place of `false`.
+        let isViewingChat = false
+
+        let options = NuggetService.notificationListener.foregroundPresentationOptions(
+            for: userInfo,
+            isViewingChat: isViewingChat
+        )
+        completionHandler(options)
     }
-    
+
+    /// The user **tapped** a notification.
+    ///
+    /// If it's a Nugget push we extract its deeplink and hand it to the UI layer to open — building
+    /// the chat screen needs the factory, which lives in the UI layer, so `AppDelegate` stays
+    /// factory-free. Otherwise we fall through to the app's own deeplink handling.
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
-        // Handle notification response
+        defer { completionHandler() }
+
         let userInfo = response.notification.request.content.userInfo
         print("Received notification with userInfo: \(userInfo)")
-        
-        // Handle the notification action here
-        completionHandler()
-    }
-    
-    func userNotificationCenter(_ center: UNUserNotificationCenter, openSettingsFor notification: UNNotification?) {
-        // Handle notification settings
-        print("Opening notification settings")
+
+        // Is this a Nugget notification? If so, hand its deeplink to the UI layer to open — building
+        // the chat screen needs the factory, which lives there (see `ViewController.openNugget(with:)`).
+        guard
+            let deeplink = NuggetService.notificationListener.nuggetDeeplink(in: userInfo),
+            NuggetService.notificationListener.canOpenNuggetDeeplink(deeplink)
+        else {
+            // Not a Nugget notification — route it through your own deeplink / notification handling.
+            return
+        }
+        // Build and present the Nugget chat screen from the UI layer.
+        ViewController().openNugget(with: deeplink)
     }
 }
 
+// MARK: - App Lock Handling
 
 private extension AppDelegate {
-    // MARK: - App Lock Handling
+
     func setupAppLockObservers() {
         NotificationCenter.default.addObserver(
             self,

--- a/NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift
+++ b/NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift
@@ -1,0 +1,171 @@
+//
+//  NuggetPushNotifications.swift
+//  NuggetSDKExample
+//
+//  Push-notification integration for the Nugget chat SDK.
+//
+//  Everything here hangs off `NuggetPushNotificationsListener` — the single APNs object owned by
+//  `AppDelegate`. AppDelegate forwards the device token and permission status to it, and the chat
+//  factory (in `NuggetService`) is built with the *same* listener, so those updates are what
+//  actually upload to Nugget's backend.
+//
+//  Responsibilities:
+//    1. Token plumbing      — forward the APNs device token / permission to Nugget
+//                             (`updateNotificationToken(_:)`, `updateNotificationPermissionStatus(_:)`,
+//                             `refreshPermissionStatus()`).
+//    2. Ownership check      — decide whether a given push / deeplink belongs to Nugget
+//                             (`canOpenNuggetDeeplink(_:)`, `nuggetDeeplink(in:)`, `isNuggetNotification(_:)`).
+//    3. Foreground behaviour — decide how to present a Nugget push while foregrounded
+//                             (`foregroundPresentationOptions(for:isViewingChat:)`).
+//
+//  Building the chat screen for a tapped push needs the factory, which lives in the UI layer
+//  (`NuggetService.getNuggetVC(deeplink:)`). AppDelegate only extracts the deeplink here and
+//  hands it to the UI layer (`ViewController.openNugget(with:)`) to open — it never builds a factory.
+//
+
+import Foundation
+import NuggetSDK
+import UIKit
+import UserNotifications
+
+
+// MARK: - Notification payload keys
+extension NuggetPushNotificationsListener {
+
+    /// Keys used inside a Nugget push-notification payload.
+    ///
+    /// A Nugget push looks like:
+    /// ```json
+    /// {
+    ///   "aps": { "alert": { "title": "...", "body": "..." }, "sound": "default" },
+    ///   "meta": {
+    ///     "deeplink": "nugget://unified-support/room?flowType=ticketing&ticketID=1234567",
+    ///     "track_id": "01KTRT...:omniTicketing-12345",
+    ///     "notification_id": "notif:omniTicketing-1234567"
+    ///   }
+    /// }
+    /// ```
+    /// The actionable bits live under `meta`.
+    enum NotificationPayloadKey {
+        /// Top-level dictionary holding Nugget metadata.
+        static let meta = "meta"
+        /// The Nugget deeplink to open when the notification is tapped.
+        static let deeplink = "deeplink"
+    }
+
+    /// `UserDefaults` key under which the last-known APNs device token (hex string) is cached, so
+    /// the listener can be seeded with it on the next launch (see `AppDelegate`'s listener init).
+    static let deviceTokenDefaultsKey = "deviceToken"
+}
+
+// MARK: - Token & permission plumbing
+
+extension NuggetPushNotificationsListener {
+
+    /// Forwards a freshly registered APNs device token to Nugget.
+    ///
+    /// Call from `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`. The raw `Data`
+    /// is hex-encoded by the SDK, so you can hand the token straight through. It is also cached in
+    /// `UserDefaults` so the listener can be seeded with it on the next launch.
+    ///
+    /// - Parameter deviceToken: The token `Data` supplied by APNs.
+    func updateNotificationToken(_ deviceToken: Data) {
+        let hexToken = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+        UserDefaults.standard.set(hexToken, forKey: Self.deviceTokenDefaultsKey)
+        tokenUpdated(to: deviceToken)
+    }
+
+    /// Forwards an APNs device token (already hex-encoded) to Nugget.
+    ///
+    /// Use this overload when you are also using FCM and already hold the APNs token as a string.
+    /// - Parameter hexToken: The APNs device token as a hex string.
+    func updateNotificationToken(_ hexToken: String) {
+        UserDefaults.standard.set(hexToken, forKey: Self.deviceTokenDefaultsKey)
+        tokenUpdated(to: hexToken)
+    }
+
+    /// Tells Nugget whether the user has granted notification permission.
+    ///
+    /// The listener forwards this to Nugget's backend (alongside the token) so the server knows
+    /// whether this device can currently receive pushes.
+    /// - Parameter status: The current `UNAuthorizationStatus`.
+    func updateNotificationPermissionStatus(_ status: UNAuthorizationStatus) {
+        permissionStatusUpdated(to: status)
+    }
+
+    /// Reads the *current* system notification settings and forwards the authorization status.
+    ///
+    /// The permission can change outside the app (Settings app), so re-sync it whenever
+    /// convenient — typically on launch and on `applicationDidBecomeActive`.
+    func refreshPermissionStatus() {
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            self?.permissionStatusUpdated(to: settings.authorizationStatus)
+        }
+    }
+}
+
+// MARK: - Deeplink / ownership checks
+
+extension NuggetPushNotificationsListener {
+
+    /// Returns whether the given deeplink is one the Nugget SDK can open.
+    ///
+    /// Thin wrapper over `NuggetFactory.canOpenDeeplink(deeplink:)` (a static check — no factory
+    /// instance required). Returns `true` only for Nugget hosts (`chat`, `zchat`,
+    /// `unified-support`).
+    ///
+    /// - Parameter deeplink: The deeplink string to validate.
+    /// - Returns: `true` if Nugget should handle it.
+    func canOpenNuggetDeeplink(_ deeplink: String) -> Bool {
+        NuggetFactory.canOpenDeeplink(deeplink: deeplink)
+    }
+
+    /// Extracts the Nugget deeplink from a remote-notification `userInfo` payload, if present.
+    ///
+    /// - Parameter userInfo: The notification's `userInfo` dictionary.
+    /// - Returns: The `meta.deeplink` string, or `nil` if the payload has no Nugget deeplink.
+    func nuggetDeeplink(in userInfo: [AnyHashable: Any]) -> String? {
+        guard
+            let meta = userInfo[NotificationPayloadKey.meta] as? [String: Any],
+            let deeplink = meta[NotificationPayloadKey.deeplink] as? String
+        else { return nil }
+        return deeplink
+    }
+
+    /// Returns whether a remote-notification payload originated from Nugget.
+    ///
+    /// A payload is a Nugget notification when it carries a `meta.deeplink` that the SDK can open.
+    /// - Parameter userInfo: The notification's `userInfo` dictionary.
+    /// - Returns: `true` if this notification belongs to Nugget.
+    func isNuggetNotification(_ userInfo: [AnyHashable: Any]) -> Bool {
+        guard let deeplink = nuggetDeeplink(in: userInfo) else { return false }
+        return canOpenNuggetDeeplink(deeplink)
+    }
+}
+
+// MARK: - Foreground presentation
+
+extension NuggetPushNotificationsListener {
+
+    /// Decides how a notification should be presented while the app is in the **foreground**.
+    ///
+    /// Call from `userNotificationCenter(_:willPresent:withCompletionHandler:)`. By default a
+    /// Nugget push is shown as a normal banner. You can suppress it (return `[]`) when the user is
+    /// already looking at the exact chat the push refers to — pass `isViewingChat: true` for that
+    /// case so the banner doesn't become noise. Non-Nugget notifications are always shown as a
+    /// banner (let your own logic decide otherwise upstream if needed).
+    ///
+    /// - Parameters:
+    ///   - userInfo: The incoming notification's `userInfo` dictionary.
+    ///   - isViewingChat: Whether the user is already viewing the chat this push refers to.
+    /// - Returns: The presentation options to pass to the completion handler.
+    func foregroundPresentationOptions(
+        for userInfo: [AnyHashable: Any],
+        isViewingChat: Bool = false
+    ) -> UNNotificationPresentationOptions {
+        if isNuggetNotification(userInfo), isViewingChat {
+            return [] // Suppress — the user is already in this conversation.
+        }
+        return [.banner, .sound, .badge]
+    }
+}

--- a/NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift
+++ b/NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift
@@ -9,58 +9,121 @@ import Foundation
 import NuggetSDK
 import UIKit
 
+/// The single integration point between the host app and the Nugget chat SDK — a holder of the
+/// SDK's two long-lived objects as **shared static** members:
+///
+/// 1. ``notificationListener`` — the one ``NuggetPushNotificationsListener``. **Every** APNs token
+///    / permission update flows through this instance and nowhere else (`AppDelegate` forwards them
+///    here). `static let` ⇒ created once, lazily, shared for the app's lifetime.
+/// 2. ``factory`` — the one ``NuggetFactory``, also `static` + lazy. Building it wires
+///    ``notificationListener`` into the SDK (the factory becomes the listener's *upload delegate*),
+///    which is what lets the forwarded token upload. Because the listener and factory share the
+///    app's lifetime, the listener never loses its uploader to a screen being torn down.
+///
+/// The factory is built **lazily** — only when a chat is first opened (``getNuggetVC(deeplink:)``)
+/// — so a normal launch creates no factory. Callers use the static API; there is no per-screen
+/// instance to construct. The SDK's delegate callbacks (auth, theme, fonts, …) are served by a
+/// single private ``delegates`` instance that lives for the app's lifetime.
+///
+/// All push-notification helpers (token plumbing, deeplink ownership checks, foreground
+/// presentation) hang off `NuggetPushNotificationsListener` in `NuggetPushNotifications.swift`.
 final class NuggetService {
-    
-    let ACCESS_TOKEN = "ACCESS_TOKEN_GOES_HERE"
-    private var pushNotificationPublisher = NuggetPushNotificationsListener(apnsToken: UserDefaults.standard.string(forKey: "deviceToken"))
-    
-    lazy var factory = initializeNuggetFactory(authDelegate: self,
-                                               sdkConfigurationDelegate: self,
-                                               notificationDelegate: pushNotificationPublisher,
-                                               chatBusinessContextDelegate: self,
-                                               deeplinkListener: self,
-                                               customThemeProviderDelegate: self,
-                                               customFontProviderDelegate: self,
-                                               ticketCreationDelegate: self)
-    
-    func getNuggetVC(deeplink: String) -> UIViewController? {
+
+    /// The one app-wide APNs listener. **Every** APNs token / permission update goes through this —
+    /// and nowhere else. `static let` ⇒ created lazily on first use, shared everywhere.
+    static let notificationListener = NuggetPushNotificationsListener(
+        apnsToken: UserDefaults.standard.string(forKey: NuggetPushNotificationsListener.deviceTokenDefaultsKey)
+    )
+
+    /// The one Nugget factory — created **lazily** on first access (i.e. first chat open) and shared
+    /// for the app's lifetime. It is wired to ``notificationListener`` (the factory becomes the
+    /// listener's upload delegate), so the token forwarded to the listener is uploaded by this
+    /// factory. A normal launch never touches it, so no factory is built up front.
+    static let factory: NuggetFactory = initializeNuggetFactory(
+        authDelegate: NuggetService.delegates,
+        sdkConfigurationDelegate: NuggetService.delegates,
+        notificationDelegate: NuggetService.notificationListener,
+        chatBusinessContextDelegate: NuggetService.delegates,
+        deeplinkListener: NuggetService.delegates,
+        customThemeProviderDelegate: NuggetService.delegates,
+        customFontProviderDelegate: NuggetService.delegates,
+        ticketCreationDelegate: NuggetService.delegates
+    )
+
+    /// Builds (but does not present) the Nugget chat view controller for a deeplink. Touching this
+    /// is what lazily creates ``factory``.
+    ///
+    /// - Parameter deeplink: A Nugget deeplink, e.g. `nugget://unified-support/room?...`.
+    /// - Returns: The chat view controller, or `nil` if the deeplink is not one Nugget can open.
+    static func getNuggetVC(deeplink: String) -> UIViewController? {
         factory.contentViewController(deeplink: deeplink)
     }
+
+    /// The single instance backing the SDK's delegate callbacks (auth, theme, fonts, …). Private —
+    /// callers use the static API above; this just gives the static ``factory`` an object to talk
+    /// to, and lives for the app's lifetime so the SDK's weak delegate references stay valid.
+    private static let delegates = NuggetService()
+
+    /// Access token used by the auth delegate. Replace with a real token from your auth backend.
+    let ACCESS_TOKEN = "YOUR_ACCESS_TOKEN_HERE"
+    private init() {}
 }
 
-extension NuggetService : NuggetAuthProviderDelegate {
-    
-    struct NuggetAuthUserInfoImp : NuggetAuthUserInfo {
+// MARK: - NuggetAuthProviderDelegate
+
+extension NuggetService: NuggetAuthProviderDelegate {
+
+    /// Concrete auth payload handed back to the SDK. `accessToken` is the only field the SDK
+    /// strictly needs; the rest describe the signed-in user.
+    struct NuggetAuthUserInfoImp: NuggetAuthUserInfo {
         var clientID: Int = 1
         var userName: String? = nil
         var userID: String = ""
         var photoURL: String = ""
         var accessToken: String = ""
     }
-    
+
+    /// Called by the SDK when it needs the current user's auth info (e.g. on chat open).
+    ///
+    /// Fetch / read your access token here and hand it back through `completion`.
+    /// - Parameter completion: Pass the populated auth info, or an error if it can't be provided.
     func authManager(requiresAuthInfo completion: @escaping ((NuggetAuthUserInfo)?, (any Error)?) -> Void) {
-        //Make api call to fetch access token or fetch it from cache
+        // Make an API call to fetch the access token, or read it from your cache.
         completion(NuggetAuthUserInfoImp(accessToken: ACCESS_TOKEN), nil)
     }
+
+    /// Called by the SDK when its cached token is rejected/expired and must be refreshed.
+    /// - Parameter completion: Pass a freshly refreshed token, or an error on failure.
     func authManager(requestRefreshAuthInfo completion: @escaping ((NuggetAuthUserInfo)?, (any Error)?) -> Void) {
-        //Access token is expired. Refresh it and return it.
+        // The access token is expired. Refresh it and return the new one.
         completion(NuggetAuthUserInfoImp(accessToken: ACCESS_TOKEN), nil)
     }
 }
 
+// MARK: - NuggetSDKConfigurationDelegate
+
 extension NuggetService: NuggetSDKConfigurationDelegate {
+
+    /// Invoked when the chat screen is dismissed. Hook any teardown / analytics here.
     func chatScreenClosedCallback() {}
-    
+
+    /// Async variant the SDK uses to fetch the Jumbo (analytics) configuration.
     func jumboConfiguration(completion: @escaping (NuggetJumboConfiguration) -> Void) {
         completion(jumboConfiguration())
     }
-    
+
+    /// The Jumbo analytics configuration. `nameSpace` scopes this app's analytics stream.
     func jumboConfiguration() -> NuggetJumboConfiguration {
         NuggetJumboConfiguration(nameSpace: "NuggetSDKTest")
     }
 }
 
+// MARK: - NuggetBusinessContextProviderDelegate
+
 extension NuggetService: NuggetBusinessContextProviderDelegate {
+
+    /// Optional business context attached to a chat/ticket: routing handle, ticket grouping,
+    /// and custom ticket/bot properties. All fields are optional.
     struct ChatSupportBusinessContext: NuggetChatBusinessContext {
         var type: String?
         var ticketID: Int?
@@ -70,48 +133,73 @@ extension NuggetService: NuggetBusinessContextProviderDelegate {
         var botProperties: [String : [String]]?
     }
 
+    /// Supplies the business context the SDK should attach to the conversation.
     func chatSupportBusinessContext(completion: @escaping (NuggetBusinessContext) -> Void) {
         completion(ChatSupportBusinessContext())
     }
 }
 
+// MARK: - NuggetThemeProviderDelegate
+
 extension NuggetService: NuggetThemeProviderDelegate {
-    // this will be default color used in sdk for light mode
+
+    /// Accent color used by the SDK in light mode (hex).
     var defaultLightModeAccentHexColor: String {
         "#7C8363"
     }
-    // this will be default color used in sdk for dark mode
+
+    /// Accent color used by the SDK in dark mode (hex).
     var defaultDarkModeAccentHexColor: String {
         "#31473A"
     }
+
+    /// Interface style the SDK should render in. `.unspecified` follows the system setting.
     var deviceInterfaceStyle: UIUserInterfaceStyle {
         .unspecified
     }
 }
 
+// MARK: - NuggetDeeplinkListener
+
 extension NuggetService: NuggetDeeplinkListener {
+
+    /// Called when a deeplink is invoked from *inside* a Nugget chat surface (e.g. a bot button).
+    ///
+    /// Route it through your app's own deeplink handling. This is distinct from handling a
+    /// *push-notification* tap — see `NuggetPushNotifications.swift` for that.
+    /// - Parameter deeplink: The URL the chat surface asked the host app to open.
     func deeplinkInvoked(deeplink: URL?) {
         print("Deeplink triggerred : \(String(describing: deeplink))")
     }
 }
 
+// MARK: - NuggetTicketCreationDelegate
+
 extension NuggetService: NuggetTicketCreationDelegate {
+
+    /// Called when a support ticket is successfully created.
+    /// - Parameter conversationID: The conversation/ticket identifier created by the backend.
     func ticketCreationSucceeded(with conversationID: String) {
         print("Ticket created successfully with conversation ID : \(conversationID)")
     }
-    
+
+    /// Called when ticket creation fails.
+    /// - Parameter errorMessage: A human-readable failure reason, if the SDK provided one.
     func ticketCreationFailed(withError errorMessage: String?) {
         print(errorMessage ?? "Ticket creation failed")
     }
 }
 
+// MARK: - NuggetFontProviderDelegate
+
 extension NuggetService: NuggetFontProviderDelegate {
-    
+
+    /// Maps the SDK's semantic font weights / sizes onto a custom font family.
     struct CustomFontMap: NuggetFontPropertiesMapping {
         var fontName: String = "PlaywriteHU"
-        
+
         var fontFamily: String = "Thin"
-        
+
         var fontWeightMapping: [NuggetFontWeights : String] = [.light: "PlaywriteHU-Thin",
                                                                .regular: "PlaywriteHU-Thin",
                                                                .medium: "PlaywriteHU-Thin",
@@ -119,7 +207,8 @@ extension NuggetService: NuggetFontProviderDelegate {
                                                                .bold: "PlaywriteHU-Thin",
                                                                .extraBold: "PlaywriteHU-Thin",
                                                                .black: "PlaywriteHU-Thin"]
-        
+
+        /// Maps each semantic font size to a concrete point size.
         func fontSizeMapping(fontSize: NuggetFontSizes) -> Int {
             switch fontSize {
             case .font050:
@@ -147,7 +236,8 @@ extension NuggetService: NuggetFontProviderDelegate {
             }
         }
     }
-    
+
+    /// The custom font mapping the SDK should use. Return `nil` to use the SDK's default fonts.
     var customFontMapping: (any NuggetFontPropertiesMapping)? {
         CustomFontMap()
     }

--- a/NuggetSDKExample/NuggetSDKExample/ViewController.swift
+++ b/NuggetSDKExample/NuggetSDKExample/ViewController.swift
@@ -8,18 +8,17 @@
 import UIKit
 
 class ViewController: UIViewController {
-    
-    private let nuggetService = NuggetService()
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        // Do any additional setup after loading the view.
-    }
 
     @IBAction func openNugget(_ sender: Any) {
-        guard let vc = nuggetService.getNuggetVC(deeplink: "dummy://unified-support/conversation?flowType=ticketing&omniTicketingFlow=true") else { return }
+        let deeplink = "nugget://unified-support/conversation?flowType=ticketing&omniTicketingFlow=true"
+        openNugget(with: deeplink)
+    }
+
+    /// Builds the Nugget chat screen for `deeplink` and pushes it onto the navigation stack.
+    ///
+    /// Called both by the in-app button and by `AppDelegate` when a Nugget push is tapped.
+    @objc func openNugget(with deeplink: String) {
+        guard let vc = NuggetService.getNuggetVC(deeplink: deeplink) else { return }
         navigationController?.pushViewController(vc, animated: true)
     }
-    
 }
-

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
         // Main Nugget binary
         .binaryTarget(
             name: "Nugget",
-            url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.32-Nugget/Nugget.xcframework.zip",
-            checksum: "b39a357482cc34f473a61a020784d6c53a33181a3d7f42fc56cbdc317b6fb0ba"
+            url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.33-Nugget/Nugget.xcframework.zip",
+            checksum: "62ab0213a4533a679957c488e3d17a0f0200daba9299e9127b1c297463f5c015"
         ),
         .target(
             name: "NuggetSDK",

--- a/README.md
+++ b/README.md
@@ -1,0 +1,176 @@
+# Nugget iOS SDK
+
+`NuggetSDK` is the iOS distribution of **Nugget** — Zomato's in-app chat / customer-support
+SDK. This repository is the **wrapper** that consumer apps integrate: it vendors the
+`Nugget.xcframework` binary and exposes a friendly, typealiased Swift API (`Nugget*`).
+
+- **Current version:** `4.5.32`
+- **Integration:** Swift Package Manager or CocoaPods
+- A runnable reference integration lives in [`NuggetSDKExample/`](NuggetSDKExample).
+
+## Requirements
+
+- iOS **14.0+**
+- Swift 5 / Xcode 16 (supported up to Xcode 16.2)
+
+## Installation
+
+### Swift Package Manager
+
+Add the package to your project (Xcode → *Add Package Dependencies…*) or in `Package.swift`:
+
+```swift
+.package(url: "https://github.com/Zomato-Nugget/nugget-sdk-ios", from: "4.5.32")
+```
+
+Then add `NuggetSDK` to your target's dependencies.
+
+### CocoaPods
+
+```ruby
+pod 'NuggetSDK', :git => 'https://github.com/Zomato-Nugget/nugget-sdk-ios', :tag => '4.5.32'
+```
+
+```bash
+pod install
+```
+
+## Usage
+
+### 1. Initialize the factory
+
+The SDK is driven by a `NuggetFactory`, created via the `initializeNuggetFactory(...)` helper.
+You supply a set of delegates — two are required, the rest are optional.
+
+```swift
+import NuggetSDK
+
+let factory = initializeNuggetFactory(
+    authDelegate: self,                 // required — provides the access token
+    sdkConfigurationDelegate: self,     // required — provides the Jumbo (analytics) config
+    notificationDelegate: notificationListener, // push-notification listener (or nil)
+    chatBusinessContextDelegate: self,  // optional — routing / ticket context
+    deeplinkListener: self,             // optional — in-chat deeplink callbacks
+    customThemeProviderDelegate: self,  // optional — accent colors / interface style
+    customFontProviderDelegate: self,   // optional — custom fonts
+    ticketCreationDelegate: self,       // optional — ticket success/failure callbacks
+)
+```
+
+See [`NuggetSDKExample/NuggetSetup/NuggetService.swift`](NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift)
+for a fully documented implementation of every delegate.
+
+| Delegate | Required? | Responsibility |
+|----------|:---------:|----------------|
+| `NuggetAuthProviderDelegate` | ✅ | Provide and refresh the user's access token. |
+| `NuggetSDKConfigurationDelegate` | ✅ | Provide the Jumbo analytics config (`nameSpace`); chat-closed callback. |
+| `NuggetPushNotificationsListener` | ⬜︎ | Carry the APNs token + permission to Nugget (see [Push Notifications](#2-push-notifications)). Pass `nil` for internal clients. |
+| `NuggetBusinessContextProviderDelegate` | ⬜︎ | Attach routing / ticket / bot context to the conversation. |
+| `NuggetDeeplinkListener` | ⬜︎ | Receive deeplinks fired from inside a chat surface. |
+| `NuggetThemeProviderDelegate` | ⬜︎ | Accent colors and light/dark interface style. |
+| `NuggetFontProviderDelegate` | ⬜︎ | Map the SDK's semantic fonts to a custom family. |
+| `NuggetTicketCreationDelegate` | ⬜︎ | Ticket-created success / failure callbacks. |
+
+`initializeNuggetFactory(...)` also accepts three further optional delegates (all default `nil`) for
+advanced use: `conversationSessionDelegate`, `chatComponentProviderDelegate`, and
+`customHeaderManagerDelegate`.
+
+Omit the parameter (or pass `[:]`) to leave every flag off. Contact the Nugget team for the full
+set of supported flags and their behavior.
+
+### 2. Push Notifications
+
+Push notifications have a dedicated, in-depth guide:
+**[docs/PushNotifications.md](docs/PushNotifications.md)**. In short:
+
+1. **Create a listener** and pass it as `notificationDelegate`:
+
+   ```swift
+   let notificationListener = NuggetPushNotificationsListener(
+       apnsToken: UserDefaults.standard.string(forKey: "deviceToken")
+   )
+   ```
+
+2. **Forward the APNs token and permission** from your `AppDelegate` — the listener uploads them
+   to Nugget so the backend can target this device:
+
+   ```swift
+   notificationListener.tokenUpdated(to: deviceToken)                  // from didRegister… (raw Data)
+   notificationListener.permissionStatusUpdated(to: settings.authorizationStatus)
+   ```
+
+   > Nugget needs the **raw APNs device token**, not an FCM token. If you also use FCM, disable
+   > swizzling and forward the same raw APNs token to both — see the
+   > [guide](docs/PushNotifications.md#using-firebase-cloud-messaging-fcm-as-well).
+
+3. **Handle a notification tap** — a Nugget push carries its deeplink under `meta.deeplink`.
+   In `didReceive`, validate it and build the chat screen:
+
+   ```swift
+   guard
+       let deeplink = (userInfo["meta"] as? [String: Any])?["deeplink"] as? String,
+       NuggetFactory.canOpenDeeplink(deeplink: deeplink),             // is it a Nugget deeplink?
+       let chatVC = factory.contentViewController(deeplink: deeplink)
+   else { return }
+   // present `chatVC`
+   ```
+
+The example app implements all of this — registration, token upload, tap handling, and in-app
+banners — in
+[`NuggetPushNotifications.swift`](NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift)
+and [`AppDelegate.swift`](NuggetSDKExample/NuggetSDKExample/AppDelegate.swift).
+
+### 3. Opening chat from a deeplink
+
+```swift
+let deeplink = "nugget://unified-support/room?flowType=ticketing&ticketID=17022537"
+
+if NuggetFactory.canOpenDeeplink(deeplink: deeplink),
+   let chatVC = factory.contentViewController(deeplink: deeplink) {
+    navigationController?.pushViewController(chatVC, animated: true)
+}
+```
+
+`canOpenDeeplink(deeplink:)` returns `true` only for Nugget hosts — `chat`, `zchat`, or
+`unified-support`. The wrapper also exposes a free function `isValidNuggetDeeplink(deeplink:)`
+that does the same check.
+
+### 4. Logout
+
+Clear the device token on the backend when the user signs out:
+
+```swift
+factory.resetNuggetSDK { success in
+    print("Nugget notification token reset: \(success)")
+}
+```
+
+## API reference
+
+| Symbol | Kind | Notes |
+|--------|------|-------|
+| `initializeNuggetFactory(authDelegate:sdkConfigurationDelegate:notificationDelegate:…)` | global func → `NuggetFactory` | Builds and returns the factory. |
+| `NuggetFactory.contentViewController(deeplink:)` | method → `UIViewController?` | Builds the chat screen for a deeplink. |
+| `NuggetFactory.canOpenDeeplink(deeplink:)` | static func → `Bool` | `true` for hosts `chat` / `zchat` / `unified-support`. |
+| `isValidNuggetDeeplink(deeplink:)` | global func → `Bool` | Convenience alias of the above. |
+| `NuggetFactory.resetNuggetSDK(completionHandler:)` | method | Clears the device token on logout. |
+| `NuggetPushNotificationsListener.tokenUpdated(to:)` | method | Forward the APNs token (`Data` or hex `String`). |
+| `NuggetPushNotificationsListener.permissionStatusUpdated(to:)` | method | Forward the `UNAuthorizationStatus`. |
+
+## Example app
+
+[`NuggetSDKExample`](NuggetSDKExample) is a complete, documented integration — factory setup,
+every delegate, and the full push-notification flow (registration, token upload, tap handling,
+in-app banners).
+
+## Troubleshooting
+
+1. **Module not found** — confirm `NuggetSDK` is added to your target; clean build folder and
+   re-resolve packages / `pod install`.
+2. **Authentication errors** — verify the `accessToken` returned from
+   `NuggetAuthProviderDelegate`.
+3. **Deeplink not opening** — check `NuggetFactory.canOpenDeeplink(deeplink:)` first.
+4. **Pushes not arriving** — make sure the APNs token is forwarded via `tokenUpdated(to:)` *after*
+   the factory exists, and that you passed the **raw APNs token** (not an FCM token).
+
+For additional support, please contact the Nugget team.

--- a/docs/PushNotifications.md
+++ b/docs/PushNotifications.md
@@ -1,34 +1,182 @@
 # Push Notifications — Setup Guide (NuggetSDK, iOS)
 
-How push notifications are wired up end‑to‑end in the **NuggetSDK** (`nugget-sdk-ios`)
-distribution wrapper: registering for APNs, handing the **APNS device token** to Nugget so
-the backend can target the device, and handling a notification **tap** by parsing the
-Nugget deeplink and opening the right chat screen.
+How push is wired end‑to‑end in **NuggetSDK** (`nugget-sdk-ios`): register for APNs, hand the
+**APNS device token** to Nugget so the backend can target the device, and open the right chat
+screen when a notification is **tapped**. All APIs are the friendly `NuggetSDK` wrapper types
+(`import NuggetSDK`).
 
-> All APIs below are the friendly `NuggetSDK` wrapper types (`import NuggetSDK`).
+> Note: The full, build‑verified implementation lives in the example app
+> ([`NuggetSDKExample`](../NuggetSDKExample)): see
+> [`NuggetService.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift),
+> [`NuggetPushNotifications.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift),
+> [`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift) and
+> [`ViewController.swift`](../NuggetSDKExample/NuggetSDKExample/ViewController.swift).
 
-> **The full, build‑verified implementation lives in the example app** — this guide explains
-> *what* each piece does and shows only the essential calls. Read alongside:
-> - [`NuggetPushNotifications.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift)
->   — `NuggetPushNotificationsListener` helpers: token / permission plumbing,
->   `canOpenNuggetDeeplink(_:)`, `nuggetDeeplink(in:)`, `foregroundPresentationOptions(for:)`.
-> - [`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift) — wires the
->   system notification callbacks (token, permission, tap) into the static listener.
-> - [`NuggetService.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift)
->   — holds the **single static listener** and the **single lazy static factory**, and builds the
->   chat screen via `NuggetService.getNuggetVC(deeplink:)`.
 
-> **Ownership at a glance.** Both SDK objects are **shared static members of `NuggetService`**:
-> `NuggetService.notificationListener` (the one `NuggetPushNotificationsListener` — **every** APNs
-> token / permission update flows through it and nowhere else) and `NuggetService.factory` (the one
-> `NuggetFactory`, created **lazily** on first chat open and wired to that listener, so the
-> forwarded token uploads). `AppDelegate` owns neither — it just forwards APNs updates to the static
-> listener, and on a tapped push forwards the deeplink to the UI layer to open. Both objects share
-> the app's lifetime, so the listener never loses its uploader to a screen being torn down.
+## 1. Summary
+
+**Mental model — two long‑lived objects:**
+
+- **One listener** (`NuggetPushNotificationsListener`) — *every* APNS token / permission update
+  goes through it, and nowhere else. It auto‑uploads to Nugget's backend.
+- **One factory** (`NuggetFactory`) — built **lazily** on first chat open. Passing the listener to
+  it as `notificationDelegate` is what lets the listener upload; the factory also builds the chat
+  screen. A normal launch builds no factory (the cached token uploads on first chat open).
+
+In the example both are shared `static` members of `NuggetService`. `AppDelegate` owns neither — it
+just forwards APNs updates to the static listener, and on a tap forwards the deeplink to the UI
+layer to open.
+
+**Two responsibilities → six things you implement:**
+
+| # | Where | What to do |
+|---|-------|-----------|
+| 1 | Your `NuggetService` | Keep **one** listener; pass it as `notificationDelegate` to `initializeNuggetFactory(...)`. |
+| 2 | `didRegister…DeviceToken` | Forward the token: `listener.tokenUpdated(to: deviceToken)` (raw `Data` is hex‑encoded for you). |
+| 3 | After `requestAuthorization` (+ recommended on `didBecomeActive`) | Forward permission: `listener.permissionStatusUpdated(to: status)`. |
+| 4 | `didReceive` (tap) | Read `meta.deeplink` → validate it's a Nugget deeplink → build the chat VC → push it. Non‑Nugget pushes fall through to your own routing. |
+| 5 | `willPresent` (foreground) | Return `[.banner, .sound, .badge]`, or `[]` to suppress when already in that chat. |
+| 6 | On logout | `factory.resetNuggetSDK { _ in }` to stop targeting this device. |
+
+**The flow, compact:**
+
+```
+register → APNs → AppDelegate.didRegister…Token → listener.tokenUpdated(to:)
+                                                     │ (cached; uploads once a factory exists)
+                                                     ▼
+                          listener ──notificationDelegate──▶ factory (lazy, on first chat open)
+
+backend push → user taps → AppDelegate.didReceive → meta.deeplink valid?
+                                                       │ yes
+                                                       ▼
+                                  UI layer: factory.contentViewController(deeplink:) → push chat
+```
+
+> Note: Internal Zomato clients can pass `notificationDelegate: nil` — the backend already routes
+> their pushes. External clients integrating Nugget for their own support flow pass a real listener.
 
 ---
 
-## 1. The flow at a glance
+## 2. AI prompt
+
+Copy everything in the box below into any AI coding assistant (alongside your project) to implement
+the integration in one pass. It is self‑contained — the exact SDK API, the ownership model, every
+case, and acceptance criteria.
+
+````text
+You are integrating the **NuggetSDK** push‑notification flow into an existing iOS app
+(Swift, UIKit, AppDelegate‑based). Goal: register for APNs, hand the device token + permission
+status to Nugget so the backend can target the device, and open the Nugget chat screen when a
+Nugget push is tapped. Match the existing app's style and AppDelegate structure.
+
+## SDK API to use (imports needed: `NuggetSDK`, `UIKit`, `UserNotifications`)
+- `NuggetPushNotificationsListener` — receives the APNS token + permission status and AUTO‑uploads
+  them to Nugget's backend (internally, once a factory is wired to it). De‑dupes repeated values,
+  so it's safe to call liberally.
+    - init(apnsToken: String? = nil, pushNotificationPermissionStatus: UNAuthorizationStatus? = nil)
+    - tokenUpdated(to: Data)    // pass the raw APNs Data — it is hex‑encoded for you
+    - tokenUpdated(to: String)  // pass an already‑hex token
+    - permissionStatusUpdated(to: UNAuthorizationStatus)
+- `initializeNuggetFactory(authDelegate:sdkConfigurationDelegate:notificationDelegate: …) -> NuggetFactory`
+  Pass your listener as `notificationDelegate`. The factory ALSO requires `authDelegate` (conforms to
+  `NuggetAuthProviderDelegate`) and `sdkConfigurationDelegate` (conforms to
+  `NuggetSDKConfigurationDelegate`), plus optional theme / font / deeplink / business-context /
+  ticket delegates — back them all with one long-lived object. If the app already builds a factory
+  for chat, just add your listener as its `notificationDelegate` — do NOT create a second factory.
+- `NuggetFactory.canOpenDeeplink(deeplink: String) -> Bool`  // STATIC; true only for hosts
+  `chat`, `zchat`, `unified-support`. `isValidNuggetDeeplink(deeplink:)` is an equivalent global func.
+- `factory.contentViewController(deeplink: String) -> UIViewController?`  // builds the chat screen
+- `factory.resetNuggetSDK(completionHandler: (Bool) -> Void)`            // clears the token on logout
+
+## Ownership model (follow exactly)
+- Keep EXACTLY ONE `NuggetPushNotificationsListener` for the whole app. EVERY token / permission
+  update goes through it — nowhere else.
+- Pass that same listener instance to `initializeNuggetFactory(..., notificationDelegate:)`. The
+  factory becomes the listener's upload delegate, so a token forwarded BEFORE any factory exists is
+  cached and uploads when the factory is first created.
+- Build the factory LAZILY — only when the first chat opens. A normal launch builds no factory; the
+  cached token uploads on first chat open. (To upload at launch instead, build the factory eagerly.)
+- Hold both as shared statics on a `NuggetService` type: `static let notificationListener` (seed it
+  with the last token cached in UserDefaults) and `static let factory = initializeNuggetFactory(...)`.
+  Back the SDK's delegates (auth, config, theme, fonts, …) with one long‑lived private instance.
+- Keep AppDelegate FREE of factory work: extract the deeplink there, open the chat from the UI layer.
+
+## Implement
+1. application(_:didFinishLaunchingWithOptions:):
+   - set `UNUserNotificationCenter.current().delegate = self` BEFORE launch finishes.
+   - `requestAuthorization(options: [.alert, .badge, .sound])`; in the completion forward the
+     resulting status (`getNotificationSettings { listener.permissionStatusUpdated(to: $0.authorizationStatus) }`)
+     and, if granted, call `UIApplication.shared.registerForRemoteNotifications()` on the main thread.
+   - (Recommended) re-sync permission on `applicationDidBecomeActive`, since it can change in the
+     Settings app. (The bare sample only forwards it once, inside the `requestAuthorization` completion.)
+2. application(_:didRegisterForRemoteNotificationsWithDeviceToken:): `listener.tokenUpdated(to: deviceToken)`.
+   Optionally cache the hex string in UserDefaults to seed the listener next launch — use ONE shared
+   key for both the write here and the seed read in the listener init, or the seed silently breaks.
+3. application(_:didFailToRegisterForRemoteNotificationsWithError:): just log — Nugget gets no token this session.
+4. userNotificationCenter(_:didReceive:withCompletionHandler:) (TAP): extract the deeplink from
+   `response.notification.request.content.userInfo`. It is NESTED two levels under `meta` — not a flat
+   top-level key:
+       let meta = userInfo["meta"] as? [String: Any]
+       let deeplink = meta?["deeplink"] as? String        // NOT userInfo["deeplink"]
+   If `deeplink` is nil OR `NuggetFactory.canOpenDeeplink(deeplink:)` is false → fall through to your
+   own routing. Otherwise hand the deeplink to your UI layer (the visible / root view controller) to
+   build via `factory.contentViewController(deeplink:)` and push/present it — keep the factory call
+   OUT of AppDelegate. ALWAYS call the completion handler (e.g. `defer { completionHandler() }`).
+5. userNotificationCenter(_:willPresent:withCompletionHandler:) (FOREGROUND): return
+   `[.banner, .sound, .badge]`, or `[]` to suppress when the user is already viewing that exact chat.
+6. On logout: `factory.resetNuggetSDK { _ in }`.
+
+## FCM (only if the app ALSO uses Firebase Cloud Messaging)
+Nugget needs the RAW APNs token, not the FCM token. Add `FirebaseAppDelegateProxyEnabled = NO`
+(Boolean) to Info.plist — this is load-bearing, not optional polish: without it Firebase swizzles
+your AppDelegate and `didRegisterForRemoteNotificationsWithDeviceToken` may never hand you the raw
+token at all. Then in that callback set BOTH: `Messaging.messaging().apnsToken = deviceToken` and
+`listener.tokenUpdated(to: deviceToken)`.
+
+## Nugget push payload (the actionable deeplink is meta.deeplink)
+```json
+{ "aps": { "alert": { "title": "...", "body": "..." }, "interruption-level": "time-sensitive" },
+  "meta": { "deeplink": "nugget://unified-support/room?flowType=ticketing&ticketID=1234567" } }
+```
+
+## Prerequisites (verify / set up)
+- Push Notifications capability enabled (+ Background Modes → Remote notifications for background pushes).
+- NuggetSDK integrated; auth/config delegates already provided to `initializeNuggetFactory(...)`.
+- APNs key/cert configured on the Nugget backend for the app's bundle id.
+
+## Acceptance criteria
+- One listener; the SAME instance is the factory's notificationDelegate.
+- Token forwarded on every registration/rotation; permission forwarded on request (and, recommended, on didBecomeActive).
+- Tapping a Nugget push opens the correct chat; non‑Nugget pushes fall through to existing routing.
+- Foreground Nugget pushes present (or are intentionally suppressed when already in that chat).
+- Logout calls resetNuggetSDK. AppDelegate contains no factory work.
+````
+
+---
+
+## 3. In-depth documentation
+
+Everything below is collapsed — expand a section only when you need its detail.
+
+> Note: This guide shows the raw `NuggetSDK` calls (`tokenUpdated`, `permissionStatusUpdated`,
+> `canOpenDeeplink`). The example app wraps several of them in thin helpers of its own
+> (`updateNotificationToken`, `refreshPermissionStatus`, `nuggetDeeplink(in:)`, `getNuggetVC`) — those
+> are convenience wrappers around the same SDK API, not different functions.
+
+<details>
+<summary><strong>Prerequisites</strong></summary>
+
+- **Push Notifications** capability enabled in your target (Signing & Capabilities).
+- **Background Modes → Remote notifications** if you want background/data pushes.
+- A configured **APNs key/cert** on the Nugget backend for your app's bundle id
+  (e.g. `com.zomato.zync` in the sample payload).
+- NuggetSDK integrated and `initializeNuggetFactory(...)` already set up
+  (see [`NuggetService.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift)).
+
+</details>
+
+<details>
+<summary><strong>How the pieces fit together</strong></summary>
 
 ```
 ┌──────────────┐  register   ┌──────────────┐  APNS token   ┌──────────────────────────────┐
@@ -60,36 +208,24 @@ Nugget deeplink and opening the right chat screen.
                             UI layer: NuggetService.getNuggetVC(deeplink:) ──▶ push chat screen
 ```
 
-There are **two responsibilities** you implement:
+**Ownership at a glance.** Both SDK objects are **shared static members of `NuggetService`**:
+`NuggetService.notificationListener` (the one listener — **every** APNs token / permission update
+flows through it and nowhere else) and `NuggetService.factory` (the one `NuggetFactory`, created
+**lazily** on first chat open and wired to that listener, so the forwarded token uploads).
+`AppDelegate` owns neither — it forwards APNs updates to the static listener, and on a tapped push
+forwards the deeplink to the UI layer to open. Both objects share the app's lifetime, so the
+listener never loses its uploader to a screen being torn down.
 
-1. **Token plumbing** — give Nugget the APNS device token (and permission status) so the
-   backend knows where to deliver chat notifications. Forward both to the one static listener,
-   `NuggetService.notificationListener` — **and nowhere else**.
-2. **Tap handling** — when a Nugget notification is tapped, validate its deeplink with the
-   listener (`canOpenNuggetDeeplink(_:)`), then open the chat screen **from the UI layer** with
-   `NuggetService.getNuggetVC(deeplink:)` (which wraps `factory.contentViewController(deeplink:)`).
-   The static factory is created only at this point — not up front.
+</details>
 
----
-
-## 2. Prerequisites
-
-- **Push Notifications** capability enabled in your target (Signing & Capabilities).
-- **Background Modes → Remote notifications** if you want background/data pushes.
-- A configured **APNs key/cert** on the Nugget backend for your app's bundle id
-  (e.g. `com.zomato.zync` in the sample payload).
-- NuggetSDK integrated and `initializeNuggetFactory(...)` already set up
-  (see [`NuggetService.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift)).
-
----
-
-## 3. Step 1 — Create the listener and pass it to the factory
+<details>
+<summary><strong>Step 1 — Create the listener and pass it to the factory</strong></summary>
 
 `NuggetPushNotificationsListener` receives the APNS token and permission status and
-**automatically uploads** them to the Nugget backend (via an internal Combine pipeline)
-whenever either changes — you never call an "upload" method yourself. Keep **one** listener for
-the whole app and pass that **same** instance to the factory as `notificationDelegate`. In the
-example both live as static members of `NuggetService`:
+**automatically uploads** them to the Nugget backend (via an internal Combine pipeline) whenever
+either changes — you never call an "upload" method yourself. Keep **one** listener for the whole
+app and pass that **same** instance to the factory as `notificationDelegate`. In the example both
+live as static members of `NuggetService`:
 
 ```swift
 final class NuggetService {
@@ -113,20 +249,20 @@ final class NuggetService {
 }
 ```
 
-> The SDK delegate callbacks (auth, theme, fonts, …) need an object, so the example backs them
-> with a single private `delegates` instance — see `NuggetService.swift`. Everyone else uses the
-> static API: `NuggetService.notificationListener` and `NuggetService.getNuggetVC(deeplink:)`.
+> Note: The SDK delegate callbacks (auth, theme, fonts, …) need an object, so the example backs them with
+> a single private `delegates` instance — see `NuggetService.swift`. Everyone else uses the static
+> API: `NuggetService.notificationListener` and `NuggetService.getNuggetVC(deeplink:)`.
 
-> **The listener can only upload once a factory is created with it.** The factory wires itself in
-> as the listener's upload delegate, so a token forwarded *before* any factory exists is held (and
+> Important: The listener can only upload once a factory is created with it. The factory wires itself in as
+> the listener's upload delegate, so a token forwarded *before* any factory exists is held (and
 > cached) but not uploaded yet. **Creating a factory is not required up front** — it is built
 > **lazily, only when a chat is first opened** (`getNuggetVC(deeplink:)`), and the cached token
 > uploads at that point. A normal launch builds no factory. If you specifically want the token
 > uploaded at launch, create the factory eagerly wherever your app owns it.
 
-> `notificationDelegate` accepts `nil`: internal Zomato clients pass `nil` (the backend already
-> routes their pushes); external clients integrating Nugget for their own support flow pass a
-> real listener.
+> Note: `notificationDelegate` accepts `nil`: internal Zomato clients pass `nil` (the backend already
+> routes their pushes); external clients integrating Nugget for their own support flow pass a real
+> listener.
 
 ### Listener API reference
 
@@ -139,36 +275,38 @@ final class NuggetService {
 
 The listener de‑dupes against the last‑uploaded value, so it's safe to call these liberally.
 
----
+</details>
 
-## 4. Step 2 — Register and forward the token / permission (AppDelegate)
+<details>
+<summary><strong>Step 2 — Register for APNs and forward the token and permission</strong></summary>
 
-In `didFinishLaunching`: set the notification‑center delegate, request authorization, forward
-the permission status, and `registerForRemoteNotifications()`. Then forward the token from the
-APNs callback. The two calls that actually feed Nugget are:
+In `didFinishLaunching`: set the notification‑center delegate, request authorization, forward the
+permission status, and `registerForRemoteNotifications()`. Then forward the token from the APNs
+callback. The two calls that actually feed Nugget are:
 
 ```swift
 // In application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
 NuggetService.notificationListener.tokenUpdated(to: deviceToken)   // raw Data is hex-encoded for you
 
-// After requesting authorization (and again on didBecomeActive, since it can change in Settings)
+// After requesting authorization (recommended: also re-sync on didBecomeActive — it can change in Settings)
 UNUserNotificationCenter.current().getNotificationSettings { settings in
     NuggetService.notificationListener.permissionStatusUpdated(to: settings.authorizationStatus)
 }
 ```
 
 Full wiring (delegate, authorization request, registration, persistence) is in
-[`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift); the example wraps
-both calls as `updateNotificationToken(_:)` / `refreshPermissionStatus()` — listener helpers in
+[`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift); the example wraps both
+calls as `updateNotificationToken(_:)` / `refreshPermissionStatus()` — listener helpers in
 [`NuggetPushNotifications.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift).
 
-> **Seed *and* forward.** On the very first launch nothing is cached, so the `init(apnsToken:)`
-> seed is `nil`; the `tokenUpdated(to:)` call in `didRegister…` is what delivers the token the
-> first time and on every later rotation.
+> Important: Seed and forward. On the very first launch nothing is cached, so the `init(apnsToken:)` seed
+> is `nil`; the `tokenUpdated(to:)` call in `didRegister…` is what delivers the token the first time
+> and on every later rotation.
 
----
+</details>
 
-## 5. Generating an APNS device token
+<details>
+<summary><strong>Generate the APNs device token (and use FCM alongside)</strong></summary>
 
 The token is produced by iOS — you *request* it and receive it in a delegate callback:
 
@@ -184,13 +322,13 @@ To read it as a hex string (e.g. for logging), or pass the raw `Data` straight t
 let apnsToken = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
 ```
 
-> APNs tokens are only delivered on a **real device** (and modern Simulators on macOS 13+ with a
+> Important: APNs tokens are only delivered on a **real device** (and modern Simulators on macOS 13+ with a
 > signed‑in Apple ID), and they **rotate** — always forward the latest one.
 
-### Using Firebase Cloud Messaging (FCM) as well
+### Use Firebase Cloud Messaging (FCM) alongside
 
-Nugget needs the **raw APNS device token**, *not* the FCM registration token. If you also use
-FCM, disable method swizzling and forward the same raw APNS token to both:
+Nugget needs the **raw APNS device token**, *not* the FCM registration token. If you also use FCM,
+disable method swizzling and forward the same raw APNS token to both:
 
 1. Add `FirebaseAppDelegateProxyEnabled = NO` (Boolean) to your **Info.plist**.
 2. In `didRegisterForRemoteNotificationsWithDeviceToken`, set both:
@@ -203,9 +341,10 @@ NuggetService.notificationListener.tokenUpdated(to: deviceToken)       // give N
 Firebase's guide on disabling swizzling:
 <https://firebase.google.com/docs/cloud-messaging/ios/get-started#disable-swizzling>
 
----
+</details>
 
-## 6. The Nugget notification payload
+<details>
+<summary><strong>The Nugget notification payload</strong></summary>
 
 A Nugget push looks like this — the actionable bits live under **`meta`**:
 
@@ -236,11 +375,12 @@ A Nugget push looks like this — the actionable bits live under **`meta`**:
 | `meta.track_id` / `meta.notification_id` | Identifiers for analytics / de‑duplication. |
 
 The deeplink encodes the destination: `flowType=ticketing`, `omniTicketingFlow=true`,
-`ticketID=17022537` → open the ticketing conversation for that ticket.
+`ticketID=1234567` → open the ticketing conversation for that ticket.
 
----
+</details>
 
-## 7. Step 3 — Handle the notification tap (deeplink → chat screen)
+<details>
+<summary><strong>Step 3 — Handle the notification tap (deeplink → chat screen)</strong></summary>
 
 On tap, iOS calls `userNotificationCenter(_:didReceive:withCompletionHandler:)` on the
 `AppDelegate`. It **extracts and validates** the deeplink via the static listener, then hands it to
@@ -267,18 +407,19 @@ deeplink to the UI layer via `ViewController.openNugget(with:)`, which builds an
 see [`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift) and
 [`ViewController.swift`](../NuggetSDKExample/NuggetSDKExample/ViewController.swift).
 
-> **`canOpenDeeplink` contract** — a static method on `NuggetFactory` that returns `true` only
-> when the deeplink's **host** is `chat`, `zchat`, or `unified-support`. The sample payload's
-> `nugget://unified-support/room?…` ⇒ host `unified-support` ⇒ `true`. The wrapper also exposes
-> a free function `isValidNuggetDeeplink(deeplink:)` that does the same check.
+> Note: The `canOpenDeeplink` contract — a static method on `NuggetFactory` that returns `true` only when
+> the deeplink's **host** is `chat`, `zchat`, or `unified-support`. The sample payload's
+> `nugget://unified-support/room?…` ⇒ host `unified-support` ⇒ `true`. The wrapper also exposes a
+> free function `isValidNuggetDeeplink(deeplink:)` that does the same check.
 
----
+</details>
 
-## 8. Step 4 — Foreground (in‑app) notifications
+<details>
+<summary><strong>Step 4 — Foreground (in‑app) notifications</strong></summary>
 
 For a push that arrives while the app is foregrounded, iOS calls `willPresent`; return the
-presentation options. Show the banner normally, or return `[]` to suppress it (e.g. when the
-user is already on that exact chat):
+presentation options. Show the banner normally, or return `[]` to suppress it (e.g. when the user is
+already on that exact chat):
 
 ```swift
 completionHandler([.banner, .sound, .badge])   // show — or [] to suppress
@@ -287,12 +428,13 @@ completionHandler([.banner, .sound, .badge])   // show — or [] to suppress
 The example centralises this decision in a listener helper —
 `NuggetService.notificationListener.foregroundPresentationOptions(for:isViewingChat:)`.
 
-> Tapping the foreground banner still routes through `didReceive response` (Step 3), so the
-> deeplink handling is shared — `willPresent` only decides whether to *display* the banner.
+> Note: Tapping the foreground banner still routes through `didReceive response` (Step 3), so the deeplink
+> handling is shared — `willPresent` only decides whether to *display* the banner.
 
----
+</details>
 
-## 9. Related: clearing the token on logout
+<details>
+<summary><strong>Clear the token on logout</strong></summary>
 
 When the user logs out, tell Nugget to stop targeting this device:
 
@@ -303,24 +445,27 @@ NuggetService.factory.resetNuggetSDK { success in print("Nugget token reset: \(s
 This makes the backend call with the token removed / permission denied, and clears the locally
 cached token.
 
----
+</details>
 
-## 10. Checklist
+<details>
+<summary><strong>Checklist</strong></summary>
 
 - [ ] Push Notifications capability (+ Background Modes if needed) enabled.
 - [ ] `UNUserNotificationCenter.current().delegate = self` set before launch finishes.
 - [ ] Exactly one `NuggetPushNotificationsListener` (here `static NuggetService.notificationListener`); the same instance is wired into the factory. **All** APNS token / permission updates go through it — nowhere else. (The factory is built lazily on first chat open — no need to create it up front; the cached token uploads then.)
-- [ ] Permission requested; `permissionStatusUpdated(to:)` forwarded to that static listener.
+- [ ] Permission requested; `permissionStatusUpdated(to:)` forwarded to that static listener (recommended: also re‑sync on `didBecomeActive`, since it can change in Settings).
 - [ ] `registerForRemoteNotifications()` called after permission granted.
 - [ ] `NuggetPushNotificationsListener` created and passed as `notificationDelegate` to `initializeNuggetFactory(...)`.
 - [ ] APNS token forwarded via `tokenUpdated(to:)` in `didRegisterForRemoteNotificationsWithDeviceToken`.
 - [ ] (FCM only) swizzling disabled; raw APNS token sent to *both* `Messaging` and Nugget.
 - [ ] Tap handling: parse `meta.deeplink` → `NuggetFactory.canOpenDeeplink(deeplink:)` → `factory.contentViewController(deeplink:)`.
 - [ ] Foreground `willPresent` returns the desired presentation options.
+- [ ] Logout calls `factory.resetNuggetSDK(completionHandler:)`.
 
----
+</details>
 
-### API quick reference (NuggetSDK wrapper)
+<details>
+<summary><strong>API quick reference (NuggetSDK wrapper)</strong></summary>
 
 | Symbol | Kind | Notes |
 |--------|------|-------|
@@ -332,3 +477,5 @@ cached token.
 | `isValidNuggetDeeplink(deeplink:)` | global func → `Bool` | Convenience alias of the above. |
 | `factory.contentViewController(deeplink:)` | method → `UIViewController?` | Builds the chat screen for a deeplink. |
 | `factory.resetNuggetSDK(completionHandler:)` | method | Clears the device token on logout. |
+
+</details>

--- a/docs/PushNotifications.md
+++ b/docs/PushNotifications.md
@@ -1,0 +1,334 @@
+# Push Notifications — Setup Guide (NuggetSDK, iOS)
+
+How push notifications are wired up end‑to‑end in the **NuggetSDK** (`nugget-sdk-ios`)
+distribution wrapper: registering for APNs, handing the **APNS device token** to Nugget so
+the backend can target the device, and handling a notification **tap** by parsing the
+Nugget deeplink and opening the right chat screen.
+
+> All APIs below are the friendly `NuggetSDK` wrapper types (`import NuggetSDK`).
+
+> **The full, build‑verified implementation lives in the example app** — this guide explains
+> *what* each piece does and shows only the essential calls. Read alongside:
+> - [`NuggetPushNotifications.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift)
+>   — `NuggetPushNotificationsListener` helpers: token / permission plumbing,
+>   `canOpenNuggetDeeplink(_:)`, `nuggetDeeplink(in:)`, `foregroundPresentationOptions(for:)`.
+> - [`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift) — wires the
+>   system notification callbacks (token, permission, tap) into the static listener.
+> - [`NuggetService.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift)
+>   — holds the **single static listener** and the **single lazy static factory**, and builds the
+>   chat screen via `NuggetService.getNuggetVC(deeplink:)`.
+
+> **Ownership at a glance.** Both SDK objects are **shared static members of `NuggetService`**:
+> `NuggetService.notificationListener` (the one `NuggetPushNotificationsListener` — **every** APNs
+> token / permission update flows through it and nowhere else) and `NuggetService.factory` (the one
+> `NuggetFactory`, created **lazily** on first chat open and wired to that listener, so the
+> forwarded token uploads). `AppDelegate` owns neither — it just forwards APNs updates to the static
+> listener, and on a tapped push forwards the deeplink to the UI layer to open. Both objects share
+> the app's lifetime, so the listener never loses its uploader to a screen being torn down.
+
+---
+
+## 1. The flow at a glance
+
+```
+┌──────────────┐  register   ┌──────────────┐  APNS token   ┌──────────────────────────────┐
+│  Your App    │ ──────────▶ │  APNs        │ ────────────▶ │ AppDelegate                  │
+│ (AppDelegate)│             │  (Apple)     │   (Data)      │ didRegisterFor…DeviceToken   │
+└──────────────┘             └──────────────┘               └───────────────┬──────────────┘
+                                                          NuggetService.notificationListener
+                                                            .updateNotificationToken(_:)
+                                                                            ▼
+                                       ┌────────────────────────────────────────────────────┐
+                                       │ NuggetService.notificationListener (static, shared)   │
+                                       │  caches the token; uploads it ONCE the factory exists │
+                                       └───────────────┬────────────────────────────────────┘
+                                                       │ wired in as notificationDelegate
+                                                       ▼
+                                       ┌────────────────────────────────────────────────────┐
+                                       │ NuggetService.factory (static, shared)                │
+                                       │  created lazily on first chat open — not up front     │
+                                       └────────────────────────────────────────────────────┘
+
+  ── Nugget backend sends a push ──────────────────────────────────────────────────────────▶
+
+┌──────────────┐  user taps  ┌──────────────────────────────┐  meta.deeplink  ┌─────────────────────────┐
+│ Notification │ ──────────▶ │ AppDelegate                  │ ──────────────▶ │ NuggetService.          │
+│  banner      │             │ didReceive response          │   (validate)    │ notificationListener    │
+└──────────────┘             └───────────────┬──────────────┘                 └────────────┬────────────┘
+                                             │ forward deeplink                              │ true
+                                             ▼                                               ▼
+                            UI layer: NuggetService.getNuggetVC(deeplink:) ──▶ push chat screen
+```
+
+There are **two responsibilities** you implement:
+
+1. **Token plumbing** — give Nugget the APNS device token (and permission status) so the
+   backend knows where to deliver chat notifications. Forward both to the one static listener,
+   `NuggetService.notificationListener` — **and nowhere else**.
+2. **Tap handling** — when a Nugget notification is tapped, validate its deeplink with the
+   listener (`canOpenNuggetDeeplink(_:)`), then open the chat screen **from the UI layer** with
+   `NuggetService.getNuggetVC(deeplink:)` (which wraps `factory.contentViewController(deeplink:)`).
+   The static factory is created only at this point — not up front.
+
+---
+
+## 2. Prerequisites
+
+- **Push Notifications** capability enabled in your target (Signing & Capabilities).
+- **Background Modes → Remote notifications** if you want background/data pushes.
+- A configured **APNs key/cert** on the Nugget backend for your app's bundle id
+  (e.g. `com.zomato.zync` in the sample payload).
+- NuggetSDK integrated and `initializeNuggetFactory(...)` already set up
+  (see [`NuggetService.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetService.swift)).
+
+---
+
+## 3. Step 1 — Create the listener and pass it to the factory
+
+`NuggetPushNotificationsListener` receives the APNS token and permission status and
+**automatically uploads** them to the Nugget backend (via an internal Combine pipeline)
+whenever either changes — you never call an "upload" method yourself. Keep **one** listener for
+the whole app and pass that **same** instance to the factory as `notificationDelegate`. In the
+example both live as static members of `NuggetService`:
+
+```swift
+final class NuggetService {
+
+    // The ONE listener — every APNS token / permission update goes through this, nowhere else.
+    static let notificationListener = NuggetPushNotificationsListener(
+        apnsToken: UserDefaults.standard.string(forKey: "deviceToken")
+    )
+
+    // The ONE factory — created lazily, wired to that same listener.
+    static let factory = initializeNuggetFactory(
+        authDelegate: delegates,
+        sdkConfigurationDelegate: delegates,
+        notificationDelegate: notificationListener,   // 👈 the single static listener
+        // …other delegates…
+    )
+
+    // Backs the SDK delegate callbacks (auth, theme, fonts, …); kept alive for the app's lifetime.
+    private static let delegates = NuggetService()
+    private init() {}
+}
+```
+
+> The SDK delegate callbacks (auth, theme, fonts, …) need an object, so the example backs them
+> with a single private `delegates` instance — see `NuggetService.swift`. Everyone else uses the
+> static API: `NuggetService.notificationListener` and `NuggetService.getNuggetVC(deeplink:)`.
+
+> **The listener can only upload once a factory is created with it.** The factory wires itself in
+> as the listener's upload delegate, so a token forwarded *before* any factory exists is held (and
+> cached) but not uploaded yet. **Creating a factory is not required up front** — it is built
+> **lazily, only when a chat is first opened** (`getNuggetVC(deeplink:)`), and the cached token
+> uploads at that point. A normal launch builds no factory. If you specifically want the token
+> uploaded at launch, create the factory eagerly wherever your app owns it.
+
+> `notificationDelegate` accepts `nil`: internal Zomato clients pass `nil` (the backend already
+> routes their pushes); external clients integrating Nugget for their own support flow pass a
+> real listener.
+
+### Listener API reference
+
+| Member | Purpose |
+|--------|---------|
+| `init(apnsToken: String? = nil, pushNotificationPermissionStatus: UNAuthorizationStatus? = nil)` | Create the listener, optionally seeded with a cached token / status. |
+| `tokenUpdated(to newToken: String)` | Update the APNS token from a hex string. |
+| `tokenUpdated(to newToken: Data)` | Update the APNS token from the raw `Data` Apple hands you — it is hex‑encoded for you. |
+| `permissionStatusUpdated(to: UNAuthorizationStatus)` | Tell Nugget whether the user granted/denied notifications. |
+
+The listener de‑dupes against the last‑uploaded value, so it's safe to call these liberally.
+
+---
+
+## 4. Step 2 — Register and forward the token / permission (AppDelegate)
+
+In `didFinishLaunching`: set the notification‑center delegate, request authorization, forward
+the permission status, and `registerForRemoteNotifications()`. Then forward the token from the
+APNs callback. The two calls that actually feed Nugget are:
+
+```swift
+// In application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+NuggetService.notificationListener.tokenUpdated(to: deviceToken)   // raw Data is hex-encoded for you
+
+// After requesting authorization (and again on didBecomeActive, since it can change in Settings)
+UNUserNotificationCenter.current().getNotificationSettings { settings in
+    NuggetService.notificationListener.permissionStatusUpdated(to: settings.authorizationStatus)
+}
+```
+
+Full wiring (delegate, authorization request, registration, persistence) is in
+[`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift); the example wraps
+both calls as `updateNotificationToken(_:)` / `refreshPermissionStatus()` — listener helpers in
+[`NuggetPushNotifications.swift`](../NuggetSDKExample/NuggetSDKExample/NuggetSetup/NuggetPushNotifications.swift).
+
+> **Seed *and* forward.** On the very first launch nothing is cached, so the `init(apnsToken:)`
+> seed is `nil`; the `tokenUpdated(to:)` call in `didRegister…` is what delivers the token the
+> first time and on every later rotation.
+
+---
+
+## 5. Generating an APNS device token
+
+The token is produced by iOS — you *request* it and receive it in a delegate callback:
+
+1. `UNUserNotificationCenter.current().requestAuthorization(options:)` — ask the user.
+2. `UIApplication.shared.registerForRemoteNotifications()` — on a granted permission.
+3. iOS calls back with either the token or an error:
+   - `application(_:didRegisterForRemoteNotificationsWithDeviceToken:)` → raw `Data`.
+   - `application(_:didFailToRegisterForRemoteNotificationsWithError:)` → failure.
+
+To read it as a hex string (e.g. for logging), or pass the raw `Data` straight to Nugget:
+
+```swift
+let apnsToken = deviceToken.map { String(format: "%02.2hhx", $0) }.joined()
+```
+
+> APNs tokens are only delivered on a **real device** (and modern Simulators on macOS 13+ with a
+> signed‑in Apple ID), and they **rotate** — always forward the latest one.
+
+### Using Firebase Cloud Messaging (FCM) as well
+
+Nugget needs the **raw APNS device token**, *not* the FCM registration token. If you also use
+FCM, disable method swizzling and forward the same raw APNS token to both:
+
+1. Add `FirebaseAppDelegateProxyEnabled = NO` (Boolean) to your **Info.plist**.
+2. In `didRegisterForRemoteNotificationsWithDeviceToken`, set both:
+
+```swift
+Messaging.messaging().apnsToken = deviceToken                          // keep FCM working
+NuggetService.notificationListener.tokenUpdated(to: deviceToken)       // give Nugget the RAW APNS token
+```
+
+Firebase's guide on disabling swizzling:
+<https://firebase.google.com/docs/cloud-messaging/ios/get-started#disable-swizzling>
+
+---
+
+## 6. The Nugget notification payload
+
+A Nugget push looks like this — the actionable bits live under **`meta`**:
+
+```json
+{
+  "Simulator Target Bundle": "com.zomato.zync",
+  "aps": {
+    "alert": {
+      "title": "Sample App",
+      "body": "Agent replied: Hello, how can I help you?"
+    },
+    "sound": "default",
+    "interruption-level": "time-sensitive"
+  },
+  "meta": {
+    "deeplink": "nugget://unified-support/room?flowType=ticketing&omniTicketingFlow=true&ticketID=1234567",
+    "track_id": "sdlkmsdcklwmdecl;ewkmc:omniTicketing-1234567",
+    "notification_id": "notif:omniTicketing-12345677"
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `aps.alert.title` / `aps.alert.body` | What iOS shows in the banner. |
+| `aps.interruption-level` | `time-sensitive` so support replies break through Focus modes. |
+| `meta.deeplink` | **The Nugget deeplink** to open on tap. Host = `unified-support` ⇒ a valid Nugget deeplink. |
+| `meta.track_id` / `meta.notification_id` | Identifiers for analytics / de‑duplication. |
+
+The deeplink encodes the destination: `flowType=ticketing`, `omniTicketingFlow=true`,
+`ticketID=17022537` → open the ticketing conversation for that ticket.
+
+---
+
+## 7. Step 3 — Handle the notification tap (deeplink → chat screen)
+
+On tap, iOS calls `userNotificationCenter(_:didReceive:withCompletionHandler:)` on the
+`AppDelegate`. It **extracts and validates** the deeplink via the static listener, then hands it to
+the UI layer — which builds the chat screen via `NuggetService.getNuggetVC(...)`. Splitting it this
+way keeps the factory lazy (created only when a chat is actually opened) and `AppDelegate` free of
+any UI/factory work:
+
+```swift
+// AppDelegate — validate + forward (no factory work here)
+guard
+    let deeplink = NuggetService.notificationListener.nuggetDeeplink(in: userInfo),   // meta.deeplink
+    NuggetService.notificationListener.canOpenNuggetDeeplink(deeplink)                // a Nugget deeplink?
+else { return }   // not a Nugget push → fall through to your own deeplink routing
+// hand the validated deeplink to the UI layer to build + present the chat
+
+// UI layer (ViewController) — build + present via the static factory
+guard let chatVC = NuggetService.getNuggetVC(deeplink: deeplink) else { return }
+navigationController?.pushViewController(chatVC, animated: true)
+```
+
+`canOpenNuggetDeeplink(_:)` / `nuggetDeeplink(in:)` are listener helpers; `getNuggetVC(deeplink:)`
+wraps `factory.contentViewController(deeplink:)`. In the example, `AppDelegate` hands the validated
+deeplink to the UI layer via `ViewController.openNugget(with:)`, which builds and pushes the chat —
+see [`AppDelegate.swift`](../NuggetSDKExample/NuggetSDKExample/AppDelegate.swift) and
+[`ViewController.swift`](../NuggetSDKExample/NuggetSDKExample/ViewController.swift).
+
+> **`canOpenDeeplink` contract** — a static method on `NuggetFactory` that returns `true` only
+> when the deeplink's **host** is `chat`, `zchat`, or `unified-support`. The sample payload's
+> `nugget://unified-support/room?…` ⇒ host `unified-support` ⇒ `true`. The wrapper also exposes
+> a free function `isValidNuggetDeeplink(deeplink:)` that does the same check.
+
+---
+
+## 8. Step 4 — Foreground (in‑app) notifications
+
+For a push that arrives while the app is foregrounded, iOS calls `willPresent`; return the
+presentation options. Show the banner normally, or return `[]` to suppress it (e.g. when the
+user is already on that exact chat):
+
+```swift
+completionHandler([.banner, .sound, .badge])   // show — or [] to suppress
+```
+
+The example centralises this decision in a listener helper —
+`NuggetService.notificationListener.foregroundPresentationOptions(for:isViewingChat:)`.
+
+> Tapping the foreground banner still routes through `didReceive response` (Step 3), so the
+> deeplink handling is shared — `willPresent` only decides whether to *display* the banner.
+
+---
+
+## 9. Related: clearing the token on logout
+
+When the user logs out, tell Nugget to stop targeting this device:
+
+```swift
+NuggetService.factory.resetNuggetSDK { success in print("Nugget token reset: \(success)") }
+```
+
+This makes the backend call with the token removed / permission denied, and clears the locally
+cached token.
+
+---
+
+## 10. Checklist
+
+- [ ] Push Notifications capability (+ Background Modes if needed) enabled.
+- [ ] `UNUserNotificationCenter.current().delegate = self` set before launch finishes.
+- [ ] Exactly one `NuggetPushNotificationsListener` (here `static NuggetService.notificationListener`); the same instance is wired into the factory. **All** APNS token / permission updates go through it — nowhere else. (The factory is built lazily on first chat open — no need to create it up front; the cached token uploads then.)
+- [ ] Permission requested; `permissionStatusUpdated(to:)` forwarded to that static listener.
+- [ ] `registerForRemoteNotifications()` called after permission granted.
+- [ ] `NuggetPushNotificationsListener` created and passed as `notificationDelegate` to `initializeNuggetFactory(...)`.
+- [ ] APNS token forwarded via `tokenUpdated(to:)` in `didRegisterForRemoteNotificationsWithDeviceToken`.
+- [ ] (FCM only) swizzling disabled; raw APNS token sent to *both* `Messaging` and Nugget.
+- [ ] Tap handling: parse `meta.deeplink` → `NuggetFactory.canOpenDeeplink(deeplink:)` → `factory.contentViewController(deeplink:)`.
+- [ ] Foreground `willPresent` returns the desired presentation options.
+
+---
+
+### API quick reference (NuggetSDK wrapper)
+
+| Symbol | Kind | Notes |
+|--------|------|-------|
+| `NuggetPushNotificationsListener` | class (`= ZChatPushNotificationsListener`) | Holds the APNS token + permission; auto‑uploads to Nugget backend. |
+| `…​.tokenUpdated(to: Data)` / `(to: String)` | method | Forward the APNS device token. |
+| `…​.permissionStatusUpdated(to:)` | method | Forward the `UNAuthorizationStatus`. |
+| `initializeNuggetFactory(…, notificationDelegate:)` | global func | Wires the listener into Nugget. |
+| `NuggetFactory.canOpenDeeplink(deeplink:)` | static func → `Bool` | `true` for hosts `chat` / `zchat` / `unified-support`. |
+| `isValidNuggetDeeplink(deeplink:)` | global func → `Bool` | Convenience alias of the above. |
+| `factory.contentViewController(deeplink:)` | method → `UIViewController?` | Builds the chat screen for a deeplink. |
+| `factory.resetNuggetSDK(completionHandler:)` | method | Clears the device token on logout. |


### PR DESCRIPTION
## Nugget - v4.5.33

Version bump of the Nugget SDK to **4.5.33**, plus the notification-handling support and documentation previously proposed in #81 (now folded into this release so they ship together).

### Version bump
- `Package.swift` binary target → `4.5.33-Nugget` (checksum updated).
- `NuggetSDK.podspec` → `4.5.33` (release URL + checksum updated).

### Docs
- New `README.md` with SDK setup/integration overview.
- New `docs/PushNotifications.md` walking through push-notification handling.

### Example app
- New `NuggetPushNotifications.swift` encapsulating push-notification setup.
- Updated `NuggetService.swift` and `AppDelegate.swift` to wire up notification handling.
- Minor `ViewController.swift` updates plus `project.pbxproj` / `Package.resolved` refresh (example app pinned at 4.5.32, the last released tag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8RuU5ik7ajkiVxtE88zrg
