### PR TITLE
Nugget - v4.5.33 checksum fix

### DIFF
--- a/NuggetSDK.podspec
+++ b/NuggetSDK.podspec
@@ -30,7 +30,7 @@ Pod::Spec.new do |s|
 
     echo "Downloading and unzipping Nugget..."
     curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.33-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
-    verify_checksum "Nugget.xcframework.zip" "62ab0213a4533a679957c488e3d17a0f0200daba9299e9127b1c297463f5c015"
+    verify_checksum "Nugget.xcframework.zip" "fc01c8f5324686b501d83dc849b33fdb1c51e92ddcf3ba5efdc6b1f480080364"
     unzip -o Nugget.xcframework.zip
     rm Nugget.xcframework.zip
   CMD

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .binaryTarget(
             name: "Nugget",
             url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.33-Nugget/Nugget.xcframework.zip",
-            checksum: "62ab0213a4533a679957c488e3d17a0f0200daba9299e9127b1c297463f5c015"
+            checksum: "fc01c8f5324686b501d83dc849b33fdb1c51e92ddcf3ba5efdc6b1f480080364"
         ),
         .target(
             name: "NuggetSDK",


### PR DESCRIPTION
## What

Corrects the `Nugget.xcframework.zip` SHA-256 pinned for **4.5.33** in both distribution manifests:

| File | Field | Old | New |
|------|-------|-----|-----|
| `Package.swift` | `binaryTarget.checksum` | `62ab0213…f5c015` | `fc01c8f5…080364` |
| `NuggetSDK.podspec` | `prepare_command` → `verify_checksum` | `62ab0213…f5c015` | `fc01c8f5…080364` |

Version (`4.5.33` / `4.5.33-Nugget`) and the asset URL are unchanged — they were already merged in #82.

## Why

The 4.5.33 version bump merged in #82 (16:26 UTC) **before** the `4.5.33-Nugget` release asset was rebuilt and re-uploaded (16:36 UTC). The rebuild changed the zip's SHA-256, so canonical `development` currently pins a checksum that no longer matches the published binary. Until this lands, every 4.5.33 consumer hits a checksum verification failure:

- **SwiftPM** — `binaryTarget` checksum mismatch at resolution.
- **CocoaPods** — `prepare_command`'s `verify_checksum` aborts the pod install.

The new checksum `fc01c8f5324686b501d83dc849b33fdb1c51e92ddcf3ba5efdc6b1f480080364` matches the digest reported by the published `4.5.33-Nugget/Nugget.xcframework.zip` asset.

## Diff
Two lines, both the same value swap. No code, version, or URL changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)