### PR TITLE
Nugget - v4.5.35

### DIFF
--- a/NuggetSDK.podspec
+++ b/NuggetSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NuggetSDK'
-  s.version          = '4.5.34'
+  s.version          = '4.5.35'
   s.summary          = 'The Nugget SDK for iOS.'
   s.description      = <<-DESC
                      A longer description of NuggetSDK.
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
     }
 
     echo "Downloading and unzipping Nugget..."
-    curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.34-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
-    verify_checksum "Nugget.xcframework.zip" "3f4c7cbc96d72f79cb36ffa357e08eefe5996a262b3d0e26a2f4a1692ec85b6c"
+    curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.35-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
+    verify_checksum "Nugget.xcframework.zip" "1272c75747db8559db3ad25c648ddeb8757a434bf9c39c78e37a1657be3010aa"
     unzip -o Nugget.xcframework.zip
     rm Nugget.xcframework.zip
   CMD

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
         // Main Nugget binary
         .binaryTarget(
             name: "Nugget",
-            url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.34-Nugget/Nugget.xcframework.zip",
-            checksum: "3f4c7cbc96d72f79cb36ffa357e08eefe5996a262b3d0e26a2f4a1692ec85b6c"
+            url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.35-Nugget/Nugget.xcframework.zip",
+            checksum: "1272c75747db8559db3ad25c648ddeb8757a434bf9c39c78e37a1657be3010aa"
         ),
         .target(
             name: "NuggetSDK",


### PR DESCRIPTION
## What

Bumps the distribution wrapper to **Nugget 4.5.35** in both manifests:

| File | Field | Change |
|------|-------|--------|
| `Package.swift` | `binaryTarget.url` | `4.5.34-Nugget` → `4.5.35-Nugget` |
| `Package.swift` | `binaryTarget.checksum` | `3f4c7cbc…ec85b6c` → `1272c757…3010aa` |
| `NuggetSDK.podspec` | `s.version` | `4.5.34` → `4.5.35` |
| `NuggetSDK.podspec` | `prepare_command` curl URL + `verify_checksum` | same version/checksum swap |

## Checksum verification

SHA-256 of the published `4.5.35-Nugget/Nugget.xcframework.zip` asset was independently recomputed from the downloaded artifact and matches the pinned value:

```
1272c75747db8559db3ad25c648ddeb8757a434bf9c39c78e37a1657be3010aa
```

## ⚠️ Before merging

The `4.5.35-Nugget` release is currently a **draft** — publish it first, otherwise the `binaryTarget` URL 404s and SwiftPM resolution / `pod install` fails for every consumer (same failure mode as the 4.5.33 incident, #83).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVqMbR6GZiCbJpgJnZDCot