### PR TITLE
Nugget - v4.5.36

### DIFF
--- a/NuggetSDK.podspec
+++ b/NuggetSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NuggetSDK'
-  s.version          = '4.5.35'
+  s.version          = '4.5.36'
   s.summary          = 'The Nugget SDK for iOS.'
   s.description      = <<-DESC
                      A longer description of NuggetSDK.
@@ -29,8 +29,8 @@ Pod::Spec.new do |s|
     }
 
     echo "Downloading and unzipping Nugget..."
-    curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.35-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
-    verify_checksum "Nugget.xcframework.zip" "1272c75747db8559db3ad25c648ddeb8757a434bf9c39c78e37a1657be3010aa"
+    curl -L https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.36-Nugget/Nugget.xcframework.zip -o Nugget.xcframework.zip
+    verify_checksum "Nugget.xcframework.zip" "743f070abd7a417761341ba5d83f1cbf17dbf64bcfa3a85d38bbb992270e6111"
     unzip -o Nugget.xcframework.zip
     rm Nugget.xcframework.zip
   CMD

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
         // Main Nugget binary
         .binaryTarget(
             name: "Nugget",
-            url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.35-Nugget/Nugget.xcframework.zip",
-            checksum: "1272c75747db8559db3ad25c648ddeb8757a434bf9c39c78e37a1657be3010aa"
+            url: "https://github.com/Zomato-Nugget/nugget-sdk-ios/releases/download/4.5.36-Nugget/Nugget.xcframework.zip",
+            checksum: "743f070abd7a417761341ba5d83f1cbf17dbf64bcfa3a85d38bbb992270e6111"
         ),
         .target(
             name: "NuggetSDK",


### PR DESCRIPTION
## What

Bumps the distribution wrapper to **Nugget 4.5.36** in both manifests:

| File | Field | Change |
|------|-------|--------|
| `Package.swift` | `binaryTarget.url` | `4.5.35-Nugget` → `4.5.36-Nugget` |
| `Package.swift` | `binaryTarget.checksum` | `1272c757…3010aa` → `743f070a…70e6111` |
| `NuggetSDK.podspec` | `version` | `4.5.35` → `4.5.36` |
| `NuggetSDK.podspec` | `prepare_command` curl URL + SHA-256 | `4.5.35-Nugget` → `4.5.36-Nugget`, checksum updated |

## What's in Nugget 4.5.36

From `Zomato/chat-sdk-ios` (4.5.35 → 4.5.36):

- **Fix: `performBatchUpdates` crash** — typing-bubble batch coordinates, gated behind the `enableTypingBubbleBatchFix` feature flag (Zomato/chat-sdk-ios#646)

## Pre-merge checklist

- [ ] Publish the **`4.5.36-Nugget`** GitHub release with `Nugget.xcframework.zip` attached — the release does not exist yet, so the pinned URL will 404 for SwiftPM/CocoaPods until it is published. The pinned SHA-256 (`743f070abd7a417761341ba5d83f1cbf17dbf64bcfa3a85d38bbb992270e6111`) has been verified against the locally built zip from today's `chat-sdk-ios` `development` (post Zomato/chat-sdk-ios#647).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155pspJhvGrAvTwLB1a8Ykp
